### PR TITLE
resolve #2 詳細表示

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -66,7 +66,12 @@ class _MyHomePageState extends State<MyHomePage> {
               builder: (context, snapshot) => snapshot.hasData
                   ? Text(snapshot.data.toString())
                   : Center(child: CircularProgressIndicator()),
-            )
+            ),
+            AssetPicturesListView(imageDatas: [
+              ["images/a.png","つくし"],
+              ["images/b.png","もみじ","とても綺麗"],
+              ["images/c.png","おはな"]
+            ])
           ],
         ));
   }

--- a/app/lib/picturesListView.dart
+++ b/app/lib/picturesListView.dart
@@ -1,18 +1,26 @@
 import 'package:flutter/material.dart';
 import 'dart:developer';
+import 'model.dart';
 
 // 画像のパスのリスト(imagePaths)を渡すと垂直に並べて一覧で表示するWidget
 class AssetPicturesListView extends StatelessWidget{
-  AssetPicturesListView({Key? key, required this.imagePaths}) : super(key: key);
-  final List imagePaths;
+  AssetPicturesListView({Key? key, required this.imageDatas}) : super(key: key);
+  final List imageDatas;
 
   @override
   Widget build(BuildContext context){
-    return ListView.builder(
-      itemCount: imagePaths.length,
-      itemBuilder: (BuildContext context, int index) {
-        return PictureCard(image: Image.asset(imagePaths[index]));
-      },
+    return Expanded(
+        child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: imageDatas.length,
+            itemBuilder: (context, index) {
+              if(imageDatas[index].length == 2){
+                return PictureCard(image: Image.asset(imageDatas[index][0]), name:imageDatas[index][1], detail:"");
+              }else{
+                return PictureCard(image: Image.asset(imageDatas[index][0]), name:imageDatas[index][1], detail:imageDatas[index][2]);
+              }
+            }
+        )
     );
   }
 }
@@ -21,14 +29,16 @@ class AssetPicturesListView extends StatelessWidget{
 class NetworkPicturesListView extends StatelessWidget{
   NetworkPicturesListView({Key? key, required this.imageUrls}) : super(key: key);
   final List imageUrls;
-
   @override
   Widget build(BuildContext context){
-    return ListView.builder(
-      itemCount: imageUrls.length,
-      itemBuilder: (BuildContext context, int index) {
-        return PictureCard(image: Image.network(imageUrls[index]));
-      },
+    return Expanded(
+        child: ListView.builder(
+          shrinkWrap: true,
+          itemCount: imageUrls.length,
+          itemBuilder: (BuildContext context, int index) {
+            return PictureCard(image: Image.network(imageUrls[index]), name:"a", detail:"");
+          },
+        )
     );
   }
 }
@@ -36,11 +46,46 @@ class NetworkPicturesListView extends StatelessWidget{
 // 画像Widgetを渡すと良い感じに加工するWidget
 // タップして詳細を表示などを実装したいときはここを変える
 class PictureCard extends StatelessWidget{
-  PictureCard({Key? key, required this.image}) : super(key: key);
+  PictureCard({Key? key, required this.image, required this.name, required this.detail}) : super(key: key);
   final Widget image;
+  final String name;
+  final String detail;
 
   @override
   Widget build(BuildContext context){
-    return Card(child: image);
+    return InkWell(
+        child: Card(child: image),
+        onTap: (){
+          _showDialog(context, image, name, detail);
+        }
+    );
   }
+}
+
+Future<void> _showDialog(BuildContext context, Widget image, String name, String detail) async {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text(name),
+        content: SingleChildScrollView(
+          child: ListBody(
+            children: <Widget>[
+              image,
+              Text(detail),
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            child: const Text('閉じる'),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      );
+    },
+  );
 }


### PR DESCRIPTION
app/lib/pictureListView.dart
画像のリストを表示し、それぞれクリックしたらプロンプトで名前/画像を表示するようにした。
以前は画像のURLのリストを引数として渡していたが、[画像のURL, 植物の名前(, 詳細説明)]のリストを渡すように変更した。

app/lib/main.dart
表示例を追加した。