### PR TITLE
resolve #19 投稿情報を地図に表示する機能

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         applicationId "com.example.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 20 //flutter.minSdkVersion
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
         android:label="app"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+
+        <meta-data android:name="com.google.android.geo.API_KEY"
+               android:value="AIzaSyBlXYCPhWAt9S0zXfCgrLlhTMr1HF7x_BU"/>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/lib/map/map.dart
+++ b/app/lib/map/map.dart
@@ -1,0 +1,136 @@
+import 'package:app/model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+// 表示のサンプル
+Future main() async {
+  await dotenv.load(fileName: ".env");
+  runApp(const MapSamplePage());
+}
+
+class MapSamplePage extends StatefulWidget {
+  const MapSamplePage({super.key});
+
+  @override
+  State<MapSamplePage> createState() => _MapSamplePageState();
+}
+
+class _MapSamplePageState extends State<MapSamplePage> {
+  //テスト用データ 百万遍付近
+  final List<UploadPost> testPosts = [
+    UploadPost(
+      name: "お花1",
+      latitude: 35.02527355160815,
+      longitude: 135.77870285267127,
+      url: "https://upload.wikimedia.org/wikipedia/commons/e/e3/Cherry_blossoms_%282004%29.jpg"
+    ),
+    UploadPost(
+      name: "お花2",
+      latitude: 35.02498254430388,
+      longitude: 135.77890210637494,
+      url: "https://upload.wikimedia.org/wikipedia/commons/3/30/Houttuynia_cordata4.jpg"
+    ),
+  ];
+  final double originLatitude = 35.0251;
+  final double originLongitude = 135.7788;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(home:Scaffold(
+      appBar: AppBar(
+        title: const Text('Map'),
+      ),
+      body: MapAndPosts(
+        latitude: originLatitude,
+        longitude: originLongitude,
+        uploadPosts: testPosts
+      )
+    ));
+  }
+}
+
+// 地図と、投稿位置にピンを表示するWidget
+// latitude, longitudeと、UploadPosts(植物名,緯度,経度,画像URL)のリストを渡すと
+// latitude, longitudeを中心としてUploadPostsの位置に対してピンを打った地図が表示される
+// ピンをタップすると詳細(写真)が表示される
+class MapAndPosts extends StatelessWidget {
+  MapAndPosts({
+    Key? key,
+    required this.latitude,
+    required this.longitude ,
+    required this.uploadPosts
+  }) : super(key: key);
+
+  late GoogleMapController mapController;
+  final double latitude;
+  final double longitude;
+  final List<UploadPost> uploadPosts;
+
+  void _onMapCreated(GoogleMapController controller) {
+    mapController = controller;
+  }
+
+  Set<Marker> _createMaker(BuildContext context , List<UploadPost> uploadPosts){
+    Set<Marker> markers = {};
+    for(int i = 0; i < uploadPosts.length; i++){
+      markers.add(Marker(
+          markerId: MarkerId(i.toString()),
+          position: LatLng(uploadPosts[i].latitude, uploadPosts[i].longitude),
+          infoWindow: InfoWindow(title: uploadPosts[i].name),
+          icon: BitmapDescriptor.defaultMarkerWithHue(BitmapDescriptor.hueGreen),
+          onTap: (){
+            _showDialog(context, uploadPosts[i]);
+          }
+      ));
+    }
+    return markers;
+  }
+
+  Future<void> _showDialog(BuildContext context, UploadPost uploadPost) async {
+    final String name = uploadPost.name;
+    //final String detail = "";
+    final Widget image = Image.network(uploadPost.url);
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(name),
+          content: SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                image,
+              ],
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('閉じる'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GoogleMap(
+      onMapCreated: _onMapCreated,
+      initialCameraPosition: CameraPosition(
+        target: LatLng(latitude, longitude),
+        zoom: 17.0,
+      ),
+      markers: _createMaker(context, uploadPosts),
+    );
+  }
+}

--- a/app/lib/model.dart
+++ b/app/lib/model.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 class Test {
   final int id;
   final String name;
@@ -10,6 +12,29 @@ class Test {
       id: json['id'],
       name: json['name'],
       hash: json['hash'],
+    );
+  }
+}
+
+class UploadPost {
+  final String name;
+  final String url;
+  final double latitude;
+  final double longitude;
+
+  UploadPost({
+    required this.name,
+    required this.url,
+    required this.latitude,
+    required this.longitude
+  });
+
+  factory UploadPost.fromJson(Map<String, dynamic> json) {
+    return UploadPost(
+      name: json['name'],
+      url: json['url'],
+      latitude: json['latitude'],
+      longitude: json['longitude']
     );
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -69,6 +69,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.7"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -121,6 +128,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1"
+  google_maps_flutter:
+    dependency: "direct main"
+    description:
+      name: google_maps_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
+  google_maps_flutter_android:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.2"
+  google_maps_flutter_ios:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.12"
+  google_maps_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.4"
   http:
     dependency: "direct main"
     description:
@@ -224,6 +259,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   string_scanner:
     dependency: transitive
     description:
@@ -261,4 +303,4 @@ packages:
     version: "2.1.2"
 sdks:
   dart: ">=2.18.2 <3.0.0"
-  flutter: ">=2.8.0"
+  flutter: ">=3.0.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
 
   # APIのためのパッケージ
   http: ^0.13.5
+  google_maps_flutter: ^2.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
lib/map/map.dart を追加
MapAndPostsクラスは、中心位置とUploadPostクラス(model.dart内)のリストを渡すと、緑のピンを打った地図を表示するWidget。
MapSamplePageクラスは表示サンプル。

lib/model.dart内にUploadPostクラスを追加
植物名、緯度、経度、画像のURL　の組

GoogleMap用のパッケージを追加
プロジェクトのパスに日本語が含まれるとうまくビルドできない可能性あり。

動作はエミュレータでのみ確認済み